### PR TITLE
Linux: support for Flatpak

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Linux runs Word Play through Proton, therefor it uses the Windows folder structu
 
 `~/.local/share/Steam/steamapps/compatdata/3586660/pfx/drive_c/users/steamuser/AppData/LocalLow/Game Maker's Toolkit/Word Play/`
 
+For Flatpak, the location is different:
+
+`~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/compatdata/3586660/pfx/drive_c/users/steamuser/AppData/LocalLow/Game Maker's Toolkit/Word Play/`
 
 You may need to show hidden files or folders to get here!
 

--- a/install_language.sh
+++ b/install_language.sh
@@ -19,7 +19,7 @@ get_save_game_path() {
         darwin*) echo $macOS_dir;;
         linux*) echo "$home_dir/.local/share/Steam/steamapps/compatdata/3586660/pfx/drive_c/users/steamuser/AppData/LocalLow/Game Maker's Toolkit/Word Play/";;
         *)
-            echo -e "${RED}Unkown OS:${NC} falling back to macOS" >&2
+            echo -e "${RED}Unknown OS:${NC} falling back to macOS" >&2
             echo $macOS_dir
         ;;
     esac

--- a/install_language.sh
+++ b/install_language.sh
@@ -17,7 +17,10 @@ get_save_game_path() {
     local macOS_dir="$home_dir/Library/Application Support/com.GMTK.WordPlay"
     case $OSTYPE in
         darwin*) echo $macOS_dir;;
-        linux*) echo "$home_dir/.local/share/Steam/steamapps/compatdata/3586660/pfx/drive_c/users/steamuser/AppData/LocalLow/Game Maker's Toolkit/Word Play/";;
+        linux*)
+            local steam_path="$home_dir/.local/share/Steam"
+            echo "$steam_path/steamapps/compatdata/3586660/pfx/drive_c/users/steamuser/AppData/LocalLow/Game Maker's Toolkit/Word Play/"
+            ;;
         *)
             echo -e "${RED}Unknown OS:${NC} falling back to macOS" >&2
             echo $macOS_dir

--- a/install_language.sh
+++ b/install_language.sh
@@ -18,7 +18,20 @@ get_save_game_path() {
     case $OSTYPE in
         darwin*) echo $macOS_dir;;
         linux*)
-            local steam_path="$home_dir/.local/share/Steam"
+            local steam_path_default="$home_dir/.local/share/Steam"
+            local steam_path_flatpak="$home_dir/.var/app/com.valvesoftware.Steam/.local/share/Steam"
+            local steam_path=
+            if [ -d "$steam_path_default" ]; then
+                steam_path="$steam_path_default"
+                echo -e "Assuming ${GREEN}default${NC} Steam directory '$steam_path'." >&2
+            elif [ -d "$steam_path_flatpak" ]; then
+                steam_path="$steam_path_flatpak"
+                echo -e "Assuming ${GREEN}Flatpak${NC} installation of Steam at '$steam_path'." >&2
+            fi
+            if [ -z "$steam_path" ]; then
+                echo -e "${RED}Error${NC}: cannot find path to Steam dir." >&2
+                steam_path="$steam_path_default"
+            fi
             echo "$steam_path/steamapps/compatdata/3586660/pfx/drive_c/users/steamuser/AppData/LocalLow/Game Maker's Toolkit/Word Play/"
             ;;
         *)
@@ -184,7 +197,7 @@ verify_save_game_path_exists() {
         echo "1. Make sure Word Play is installed"
         echo "2. Run Word Play at least once to create the save directory"
         echo "3. Check that the game has proper permissions"
-        [[ "$OSTYPE" == linux* ]] && echo '4. Check if the game was installed in the default steam library, i.e. `~/.local/share/Steam/steamapps/` this is the only supported configuration currently'
+        [[ "$OSTYPE" == linux* ]] && echo '4. Check where the game was installed. The default steam library is `~/.local/share/Steam/steamapps/`. For Flatpak, it is `~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/`. These two are the only supported configurations.'
             
         return 1
     fi


### PR DESCRIPTION
Details about the implementation are in the third commit's message. I tried to follow the code style of the existing shell script as best as I could, feel free to shout at me if I missed something.

### Testing

<details><summary>I tested successful installation. Here's Bash output:</summary>

Because the function `get_save_game_path()` is called twice, the log message appears twice in the output, but I think it's not a big problem.

```
$ ./install_language.sh 
Word Play Language Mod Installer
Select a language to install:

  1. English (remove custom files)
  2. brazilian-portuguese
  3. catalan
  4. french
  5. german
  6. norwegian (bokmål)
  7. norwegian (nynorsk)
  8. romanian
  9. spanish

Enter the number of your choice (1-9): 5
Assuming Flatpak installation of Steam at '/home/andrei/.var/app/com.valvesoftware.Steam/.local/share/Steam'.
Assuming Flatpak installation of Steam at '/home/andrei/.var/app/com.valvesoftware.Steam/.local/share/Steam'.
Installing german language mod (with compressed dictionary)...
Source: /home/andrei/repos/open-source/wordplay-languages/german
Destination: /home/andrei/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/compatdata/3586660/pfx/drive_c/users/steamuser/AppData/LocalLow/Game Maker's Toolkit/Word Play/

Extracting compressed dictionary...
✓ Found customdictionary.txt

✓ Copied customdictionary.txt
✓ Copied customletterbag.txt

Successfully installed german language mod!
The game should show 'Custom Dictionary' and 'Custom Letter Bag' in the bottom left corner when starting a new game.
```

and with coloring:

<img width="1281" height="438" alt="Screenshot_20250718_001439_bash installed v2" src="https://github.com/user-attachments/assets/9ccdaa69-5c1e-421a-8032-d6825b34c50a" />
</details>

The markers  'Custom Dictionary' and 'Custom Letter Bag' are shown in the game in the corner and the word [stressig](https://en.wiktionary.org/wiki/stressig) from the new dictionary is working:
<details><summary>In-game screenshot</summary>
<img width="1301" height="803" alt="Screenshot_20250718_000821_German installed" src="https://github.com/user-attachments/assets/bd3cfb00-1a57-4315-9cfa-7919aa618178" />
</details>

<details><summary>I also made sure that the error codepath is working properly by breaking the paths:</summary>

```diff
diff --git a/install_language.sh b/install_language.sh
index 2561aa5..bde78c7 100755
--- a/install_language.sh
+++ b/install_language.sh
@@ -18,8 +18,8 @@ get_save_game_path() {
     case $OSTYPE in
         darwin*) echo $macOS_dir;;
         linux*)
-            local steam_path_default="$home_dir/.local/share/Steam"
-            local steam_path_flatpak="$home_dir/.var/app/com.valvesoftware.Steam/.local/share/Steam"
+            local steam_path_default="$home_dir/.xlocal/share/Steam"
+            local steam_path_flatpak="$home_dir/.xvar/app/com.valvesoftware.Steam/.local/share/Steam"
             local steam_path=
             if [ -d "$steam_path_default" ]; then
                 steam_path="$steam_path_default"
```
</details>

<details><summary>Bash output when testing the error codepath of the script when the above diff is applied locally:</summary>

```
$ ./install_language.sh 
Word Play Language Mod Installer
Select a language to install:

  1. English (remove custom files)
  2. brazilian-portuguese
  3. catalan
  4. french
  5. german
  6. norwegian (bokmål)
  7. norwegian (nynorsk)
  8. romanian
  9. spanish

Enter the number of your choice (1-9): 5
Error: cannot find path to Steam dir.
Error: Word Play save game directory not found at:
  /home/andrei/.xlocal/share/Steam/steamapps/compatdata/3586660/pfx/drive_c/users/steamuser/AppData/LocalLow/Game Maker's Toolkit/Word Play/

Troubleshooting:
1. Make sure Word Play is installed
2. Run Word Play at least once to create the save directory
3. Check that the game has proper permissions
4. Check where the game was installed. The default steam library is `~/.local/share/Steam/steamapps/`. For Flatpak, it is `~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/`. These two are the only supported configurations.
```

with coloring:
<img width="1253" height="391" alt="Screenshot_20250718_001439_bash error output" src="https://github.com/user-attachments/assets/4748776f-3bbe-422a-a724-d11952818add" />
</details>

### Notes

<details><summary>For reference, I installed Steam via Flatpak using KDE's Discover:</summary>

Documentation: <https://apps.kde.org/discover/>

<img width="961" height="344" alt="Screenshot_20250718_002426 Steam installed in Discover v2" src="https://github.com/user-attachments/assets/e758a295-6c15-442e-945f-5f387077a04d" />

</details>