### PR TITLE
Update install_language.ps1 encoding to UTF-8 with BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ chmod +x install_language.sh
 ```
 
 ### Windows
+You most likely will need to enable ps1 script 
 ```powershell
-.\install_language.ps1 <language_name>
+Set-ExecutionPolicy -Scope CurrentUser RemoteSigned
 
+.\install_language.ps1 <language_name>
 # List available languages
 .\install_language.ps1 --list
 
@@ -45,7 +47,7 @@ If you prefer to install manually, you'll need to find the folder with your save
 `%USERPROFILE%\AppData\LocalLow\Game Maker's Toolkit\Word Play`
 
 ### Linux
-Linux runs Word Play through Proton, therefor it uses the Windows folder structure nested inside the `compatdata` folder. This folder is relative to the `steamapps` folder you installed the game in. The default location is:
+Linux runs Word Play through Proton, therefore, it uses the Windows folder structure nested inside the `compatdata` folder. This folder is relative to the `steamapps` folder you installed the game in. The default location is:
 
 `~/.local/share/Steam/steamapps/compatdata/3586660/pfx/drive_c/users/steamuser/AppData/LocalLow/Game Maker's Toolkit/Word Play/`
 

--- a/install_language.ps1
+++ b/install_language.ps1
@@ -1,4 +1,4 @@
-# Word Play Language Mod Installer for Windows
+﻿# Word Play Language Mod Installer for Windows
 # Works on all Windows systems by default (PowerShell comes pre-installed)
 # Usage: .\install_language.ps1 <language_name>
 


### PR DESCRIPTION
Hi,

To make the script compatible with Windows Powershell, it must be encoded in UTF-8 with BOM, not just simple UTF-8.
The script now starts without crashing.
